### PR TITLE
Addition of "right-managewiki-restricted"

### DIFF
--- a/i18n/miraheze/es.json
+++ b/i18n/miraheze/es.json
@@ -41,6 +41,7 @@
 	"restriction-level-user": "Permitir solo los usuarios registrados",
 	"right-createwiki": "Crear wikis",
 	"right-managewiki": "Administrar wikis",
+	"right-managewiki-restricted": "Administrar wikis restringidas",
 	"right-user": "Editar páginas protegidas como «Solo usuarios registrados»",
 	"sitematrix": "Lista de wikis de Miraheze",
 	"sitematrix-summary": "Esta página especial lista todas wikis de Miraheze.",


### PR DESCRIPTION
Addition of "right-managewiki-restricted" for "managewiki-restricted" right description. I forgot to add it in the previous patch, sorry. I request your merger. Thanks.