### PR TITLE
Hard redirects all pages like Mh:Wiki:Page as global interwiki

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -63,6 +63,9 @@
 		],
 		"HtmlPageLinkRendererEnd": [
 			"MirahezeMagicHooks::onHtmlPageLinkRendererEnd"
+		],
+		"InitializeArticleMaybeRedirect": [
+			"MirahezeMagicHooks::onInitializeArticleMaybeRedirect"
 		]
 	},
 	"manifest_version": 2

--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -132,6 +132,27 @@ class MirahezeMagicHooks {
 		return true;
 	}
 
+	/**
+	 * Hard redirects all pages like Mh:Wiki:Page as global interwiki.
+	 */
+	public static function onInitializeArticleMaybeRedirect( $title, $request, &$ignoreRedirect, &$target, $article ) {
+		$title = explode( ':', $title );
+		$prefix = strtolower( $title[0] );
+
+		if ( count( $title ) < 3 || $prefix !== 'mh' ) {
+			return true;
+		}
+
+		$wiki = strtolower( $title[1] );
+		$page = join( ':', array_slice( $title, 2 ) );
+		$page = str_replace( ' ', '_', $page );
+		$page = urlencode( $page );
+
+		$target = "https://$wiki.miraheze.org/wiki/$page";
+
+		return true;
+	}
+
 	public static function onTitleReadWhitelist( Title $title, User $user, &$whitelisted ) {
 		if ( $title->equals( Title::newMainPage() ) ) {
 			$whitelisted = true;


### PR DESCRIPTION
This would allow for users to interwiki to Miraheze, but not need to setup an interwiki for all Miraheze wikis.

For example if they had `miraheze:` as `https://meta.miraheze.org/wiki/$1`, they would be able to use `[[miraheze:mh:test:Example]]` to access `https://test.miraheze.org/wiki/Example`.