### PR TITLE
check root title against special pages

### DIFF
--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -196,7 +196,7 @@ class MirahezeMagicHooks {
 		];
 
 		foreach ( $specialsArray as $page ) {
-			if ( $title->equals( SpecialPage::getTitleFor( $page ) ) ) {
+			if ( $title->getRootTitle->equals( SpecialPage::getTitleFor( $page ) ) ) {
 				$whitelisted = true;
 				return;
 			}

--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -196,7 +196,7 @@ class MirahezeMagicHooks {
 		];
 
 		foreach ( $specialsArray as $page ) {
-			if ( $title->getRootTitle->equals( SpecialPage::getTitleFor( $page ) ) ) {
+			if ( $title->getRootTitle()->equals( SpecialPage::getTitleFor( $page ) ) ) {
 				$whitelisted = true;
 				return;
 			}


### PR DESCRIPTION
Special:CentralAutoLogin/setCookies (required for login) won't work with the current system, but should when checking the root title instead