### PR TITLE
Miraheze-ifying ca admin merge message

### DIFF
--- a/i18n/overrides/en.json
+++ b/i18n/overrides/en.json
@@ -1,7 +1,8 @@
 {
 	"@metadata": {
 		"authors": [
-			"John Lewis"
+			"John Lewis",
+			"RhinosF1"
 		]
 	},
 	"miraheze-dberr-again": "Try waiting a few minutes and reloading. For more information on this error please check out our twitter page (Twitter.com/Miraheze) or contact the system administrators by connecting to #miraheze on irc.freenode.net",
@@ -10,5 +11,7 @@
 	"miraheze-privacypage": "m:Privacy Policy",
 	"miraheze-prefs-help-realname": "Real name is optional. If you choose to provide it, this will be used for giving you attribution for your work. Also, by using a wiki hosted by Miraheze, you agree to the <span class=\"plainlinks\">[https://meta.miraheze.org/wiki/Terms_of_Use Terms of Use]</span> and accept the <span class=\"plainlinks\">[https://meta.miraheze.org/wiki/Privacy_Policy Privacy Policy]</span>",
 	"miraheze-shoutwiki-loginform-tos": "I have read, understood and agree to the [https://meta.miraheze.org/wiki/Terms_of_Use Terms of Use] and [https://meta.miraheze.org/wiki/Privacy_Policy Privacy Policy]",
-	"miraheze-shoutwiki-must-accept-tos": "You must accept the Terms of Use in order to be able to create an account!"
+	"miraheze-shoutwiki-must-accept-tos": "You must accept the Terms of Use in order to be able to create an account!",
+	"centralauth-merge-method-admin": "Manually Merged Account",
+	"centralauth-merge-method-admin-desc": "This account was manually merged by a Sysadmin or Steward. This may have been due to a technical issue in a rename or merge process."
 }

--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -71,6 +71,8 @@ class MirahezeMagicHooks {
 			'shoutwiki-loginform-tos',
 			'shoutwiki-must-accept-tos',
 			'oathauth-step1',
+			'centralauth-merge-method-admin-desc',
+			'centralauth-merge-method-admin',
 		);
 
 		if ( in_array( $lcKey, $keys, true ) ) {


### PR DESCRIPTION
The current messages don't make sense in our context. CA is global so globally overriding.