### PR TITLE
Set echo_event.event_agent_ip to null regardless if it is already null

### DIFF
--- a/maintenance/removePII.php
+++ b/maintenance/removePII.php
@@ -129,6 +129,16 @@ class RemovePII extends Maintenance {
 					]
 				]
 			],
+			'echo_event' => [
+				[
+					'fields' => [
+						'event_agent_ip' => NULL
+					],
+					'where' => [
+						'event_agent_id' => $userId
+					]
+				]
+			],
 			'flow_tree_revision' => [
 				[
 					'fields' => [


### PR DESCRIPTION
Adds a extra layer of protection to make sure this ip is removed.