### PR TITLE
Fix renaming private wikis directory

### DIFF
--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -51,7 +51,7 @@ class MirahezeMagicHooks {
 
 		if ( file_exists( "/mnt/mediawiki-static/{$old}" ) ) {
 			Shell::command( '/bin/mv', "/mnt/mediawiki-static/{$old}", "/mnt/mediawiki-static/{$new}" )->execute();
-		} else if ( "/mnt/mediawiki-static/private/{$old}" ) {
+		} else if ( file_exists( "/mnt/mediawiki-static/private/{$old}" ) ) {
 			Shell::command( '/bin/mv', "/mnt/mediawiki-static/private/{$old}", "/mnt/mediawiki-static/private/{$new}" )->execute();
 		}
 
@@ -61,7 +61,7 @@ class MirahezeMagicHooks {
 	public static function onCreateWikiStatePrivate( $dbname ) {
 		$limits = [ 'memory' => 0, 'filesize' => 0, 'time' => 0, 'walltime' => 0 ];
 		
-		if ( file_exists( "/mnt/mediawiki-static/{$dbname}/sitemaps" ) {
+		if ( file_exists( "/mnt/mediawiki-static/{$dbname}/sitemaps" ) ) {
 			Shell::command( '/bin/rm', '-rf', "/mnt/mediawiki-static/{$dbname}/sitemaps" )
 				->limits( $limits )
 				->execute();

--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -51,6 +51,8 @@ class MirahezeMagicHooks {
 
 		if ( file_exists( "/mnt/mediawiki-static/{$old}" ) ) {
 			Shell::command( '/bin/mv', "/mnt/mediawiki-static/{$old}", "/mnt/mediawiki-static/{$new}" )->execute();
+		} else if ( "/mnt/mediawiki-static/private/{$old}" ) {
+			Shell::command( '/bin/mv', "/mnt/mediawiki-static/private/{$old}", "/mnt/mediawiki-static/private/{$new}" )->execute();
 		}
 
 		static::removeRedisKey( "*{$old}*" );
@@ -58,9 +60,12 @@ class MirahezeMagicHooks {
 
 	public static function onCreateWikiStatePrivate( $dbname ) {
 		$limits = [ 'memory' => 0, 'filesize' => 0, 'time' => 0, 'walltime' => 0 ];
-		Shell::command( '/bin/rm', '-rf', "/mnt/mediawiki-static/{$dbname}/sitemaps" )
-			->limits( $limits )
-			->execute();
+		
+		if ( file_exists( "/mnt/mediawiki-static/{$dbname}/sitemaps" ) {
+			Shell::command( '/bin/rm', '-rf', "/mnt/mediawiki-static/{$dbname}/sitemaps" )
+				->limits( $limits )
+				->execute();
+		}
 	}
 
 	public static function onCreateWikiTables( &$tables ) {


### PR DESCRIPTION
Fixes an issue where renaming a private wiki doesn't rename its static directory.

Also adds a check to make sure sitemaps directory exists before removing it (if switching to private mode).