### PR TITLE
Remove Special:Interwiki from whitelisted special pages

### DIFF
--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -208,7 +208,6 @@ class MirahezeMagicHooks {
 			'CentralLogin',
 			'ConfirmEmail',
 			'CreateAccount',
-			'Interwiki',
 			'Notifications',
 			'ResetPassword'
 		];


### PR DESCRIPTION
Reverts this commit (https://github.com/miraheze/mw-config/commit/24b75ad4dc9141fe46723d1d7f370d2d01feb7b3); no pre-existing consensus for this whitelisting on all private wikis. Discussed with @JohnFLewis and @MacFan4000 on IRC