### PR TITLE
MirahezeMagicHooks::onCreateWikiDeletion: Fix param for dbw->delete

### DIFF
--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -33,7 +33,7 @@ class MirahezeMagicHooks {
 
 		$dbw = wfGetDB( DB_MASTER, [], $config->get( 'EchoSharedTrackingDB' ) );
 
-		$dbw->delete( 'echo_unread_wikis', '*', [ 'euw_wiki' => $wiki ] );
+		$dbw->delete( 'echo_unread_wikis', [ 'euw_wiki' => $wiki ] );
 
 		if ( file_exists( "/mnt/mediawiki-static/$wiki" ) ) {
 			Shell::command( '/bin/rm', '-rf', "/mnt/mediawiki-static/$wiki" )->execute();


### PR DESCRIPTION
it has 3 params but only 2 are really usable. Its not a select query so we don't need "*".