### PR TITLE
Avoid filtering automatic account creation

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -37,6 +37,9 @@
 		"MirahezeSurvey": "SpecialMirahezeSurvey"
 	},
 	"Hooks": {
+		"AbuseFilterShouldFilterAction": [
+			"MirahezeMagicHooks::onAbuseFilterShouldFilterAction"
+		],
 		"CreateWikiCreation": [
 			"MirahezeMagicHooks::onCreateWikiCreation"
 		],

--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -19,7 +19,7 @@ class MirahezeMagicHooks {
 		User $user,
 		array &$skipReasons
 	) {
-		$action = $vars->getComputedVariable( 'action' )->toString();
+		$action = $vars->getVar( 'action' )->toString();
 		if ( $action === 'autocreateaccount' ) {
 			$skipReasons[] = "Blocking automatic account creation is not allowed";
 			return false;

--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -4,6 +4,29 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Shell\Shell;
 
 class MirahezeMagicHooks {
+	/**
+	 * Avoid filtering automatic account creation
+	 *
+	 * @param AbuseFilterVariableHolder $vars
+	 * @param Title $title
+	 * @param User $user
+	 * @param array &$skipReasons
+	 * @return bool
+	 */
+	public static function onAbuseFilterShouldFilterAction(
+		AbuseFilterVariableHolder $vars,
+		Title $title,
+		User $user,
+		array &$skipReasons
+	) {
+		$action = $vars->getComputedVariable( 'action' )->toString();
+		if ( $action === 'autocreateaccount' ) {
+			$skipReasons[] = "Blocking automatic account creation is not allowed";
+			return false;
+		}
+		return true;
+	}
+
 	public static function onCreateWikiCreation( $DBname ) {
 		// Create static directory for wiki
 		if ( !file_exists( "/mnt/mediawiki-static/{$DBname}" ) ) {


### PR DESCRIPTION
Prevents AbuseFilter from applying to the `autocreateaccount` action.