### PR TITLE
Add email notifications on privileged actions

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -30,6 +30,7 @@
 	},
 	"AutoloadClasses": {
 		"MirahezeIRCRCFeedFormatter": "includes/MirahezeIRCRCFeedFormatter.php",
+		"MirahezeMagicLogEmailManager": "includes/MirahezeMagicLogEmailManager.php",
 		"MirahezeMagicHooks": "includes/MirahezeMagicHooks.php",
 		"SpecialMirahezeSurvey": "includes/SpecialMirahezeSurvey.php"
 	},
@@ -81,10 +82,16 @@
 		],
 		"UserGetRightsRemove": [
 			"MirahezeMagicHooks::onUserGetRightsRemove"
+		],
+		"RecentChange_save": [
+			"MirahezeMagicHooks::onRecentChange_save"
 		]
 	},
 	"ConfigRegistry": {
 		"mirahezemagic": "GlobalVarConfig::newInstance"
 	},
+	"ServiceWiringFiles": [
+		"includes/ServiceWiring.php"
+	],
 	"manifest_version": 2
 }

--- a/includes/MirahezeMagicLogEmailManager.php
+++ b/includes/MirahezeMagicLogEmailManager.php
@@ -1,0 +1,63 @@
+<?php
+
+use MediaWiki\Permissions\PermissionManager;
+
+class MirahezeMagicLogEmailManager {
+	/** @var Config */
+	private $config;
+
+	/** @var PermissionManager */
+	private $permissionManager;
+
+	/**
+	 * @param Config $config
+	 * @param PermissionManager $permissionManager
+	 */
+	public function __construct( Config $config, PermissionManager $permissionManager ) {
+		$this->config = $config;
+		$this->permissionManager = $permissionManager;
+	}
+
+	/**
+	 * @return array[] in format of [ 'right' => string, 'email' => string ]
+	 */
+	private function getLogConditions() : array {
+		return $this->config->get( 'MirahezeMagicLogEmailConditions' );
+	}
+
+	/**
+	 * Find all matching log email conditions for the rights the specified user has.
+	 * @param User $user
+	 * @return array
+	 */
+	public function findForUser( User $user ) : array {
+		$rights = $this->permissionManager->getUserPermissions( $user );
+
+		$found = [];
+		foreach ( $this->getLogConditions() as $condition ) {
+			if ( in_array( $condition['right'], $rights ) ) {
+				$found[] = $condition;
+			}
+		}
+
+		return $found;
+	}
+
+	/**
+	 * @param array $data Array with keys 'user_name', 'wiki_id', 'log_type', 'comment_text'
+	 * @param string $email Email to send to
+	 */
+	public function sendEmail( array $data, string $email ) {
+		DeferredUpdates::addCallableUpdate( function () use ( $data, $email ) {
+			$adminAddress = new MailAddress( $this->config->get( 'PasswordSender' ),
+				wfMessage( 'emailsender' )->inContentLanguage()->text() );
+
+			UserMailer::send(
+				new MailAddress( $email ),
+				$adminAddress,
+				'User action notification',
+				json_encode( $data )
+			);
+		} );
+	}
+}

--- a/includes/ServiceWiring.php
+++ b/includes/ServiceWiring.php
@@ -1,0 +1,15 @@
+<?php
+
+use MediaWiki\MediaWikiServices;
+
+/**
+ * DI service wiring for the MirahezeMagic extension.
+ */
+return [
+	'MirahezeMagic.LogEmailManager' => static function ( MediaWikiServices $services ) : MirahezeMagicLogEmailManager {
+		return new MirahezeMagicLogEmailManager(
+			$services->getConfigFactory()->makeConfig( 'mirahezemagic' ),
+			$services->getPermissionManager()
+		);
+	},
+];


### PR DESCRIPTION
Untested proof of concept. Expected to work like this:

```php
$wgAvailableRights[] = 'watched-person';

$wgMirahezeMagicLogEmailConditions = [
	[
		'right' => 'watched-person',
		'email' => 'watchers@shadycorp.invalid',
	],
];
```