### PR TITLE
Whitelist Special:Preferences and Special:Watchlist

### DIFF
--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -261,7 +261,9 @@ class MirahezeMagicHooks {
 			'CreateAccount',
 			'Notifications',
 			'OAuth',
-			'ResetPassword'
+			'ResetPassword',
+			'Preferences',
+			'Watchlist'
 		];
 
 		if ( $title->isSpecialPage() ) {


### PR DESCRIPTION
Per discussion with @Reception123, and also @RhinosF1, on IRC following https://phabricator.miraheze.org/T7257, which reminded me of this commit I wanted to make. As these pages are essential for users managing their own private data, which is copied to local wikis, it's essential they have access to these pages to do this. This should, in turn, allow them to disable their own notifications, I think, as the former is likely the missing link. In the latter case, MediaWiki adds one's own user page to their watchlist automatically by default on attaching one's account and there's no way to disable it (that is, you can disable watchlisting pages you edit, but not this). In any case, it's fine because either the user was a former `member` and wants to remove the pages from their watchlist to stop Echo notifications or they want to remove their own user page from a private wiki they visited inadvertently