### PR TITLE
fix AbuseFilterShouldFilterAction hook for 1.36 and add notes

### DIFF
--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Extension\AbuseFilter\AbuseFilterServices;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Shell\Shell;
 
@@ -12,6 +13,11 @@ class MirahezeMagicHooks {
 	 * @param User $user
 	 * @param array &$skipReasons
 	 * @return bool
+	 *
+	 * @note on 1.36 AbuseFilterVariableHolder is a deprecated class alias for
+	 * MediaWiki\Extension\AbuseFilter\Variables\VariableHolder, this is
+	 * incompatible with 1.35, and should be replaced when Miraheze uses
+	 * 1.36 in production.
 	 */
 	public static function onAbuseFilterShouldFilterAction(
 		AbuseFilterVariableHolder $vars,
@@ -19,6 +25,15 @@ class MirahezeMagicHooks {
 		User $user,
 		array &$skipReasons
 	) {
+		/**
+		 * AbuseFilterVariableHolder::getVar was removed on 1.36,
+		 * use AbuseFilter's new VariablesManager service on 1.36 instead.
+		 * This check should be removed when Miraheze uses 1.36 in production.
+		 */
+		if ( version_compare( MW_VERSION, '1.35', '>' ) ) {
+			$vars = AbuseFilterServices::getVariablesManager();
+		}
+
 		$action = $vars->getVar( 'action' )->toString();
 		if ( $action === 'autocreateaccount' ) {
 			$skipReasons[] = "Blocking automatic account creation is not allowed";


### PR DESCRIPTION
Should maintain compatibility with 1.35 for now.