### PR TITLE
RebuildVersionCache: Support rebuilding for all extensions

### DIFF
--- a/maintenance/rebuildVersionCache.php
+++ b/maintenance/rebuildVersionCache.php
@@ -54,8 +54,7 @@ class RebuildVersionCache extends Maintenance {
 		$queue = array_fill_keys( array_merge(
 				glob( $this->getConfig()->get( 'ExtensionDirectory' ) . '/*/extension*.json' ),
 				glob( $this->getConfig()->get( 'ExtensionDirectory' ) . '/SocialProfile/*/extension.json' ),
-				glob( $this->getConfig()->get( 'StyleDirectory' ) . '/*/skin.json' ),
-				glob( $this->getConfig()->get( 'StyleDirectory' ) . '/*/*/skin.json' )
+				glob( $this->getConfig()->get( 'StyleDirectory' ) . '/*/skin.json' )
 			),
 		true );
 

--- a/maintenance/rebuildVersionCache.php
+++ b/maintenance/rebuildVersionCache.php
@@ -23,6 +23,9 @@
  *
  * @file
  * @ingroup Maintenance
+ *
+ * @author Universal Omega
+ * @version 1.0
  */
 
 require_once( __DIR__ . '/../../../maintenance/Maintenance.php' );

--- a/maintenance/rebuildVersionCache.php
+++ b/maintenance/rebuildVersionCache.php
@@ -76,7 +76,7 @@ class RebuildVersionCache extends Maintenance {
 		);
 
 		foreach ( $extensionCredits as $extension => $extensionData ) {
-			if ( isset( $data['path'] ) ) {
+			if ( isset( $extensionData['path'] ) ) {
 				$extensionPath = dirname( $extensionData['path'] );
 				$gitInfo = new GitInfo( $extensionPath, false );
 

--- a/maintenance/rebuildVersionCache.php
+++ b/maintenance/rebuildVersionCache.php
@@ -53,7 +53,7 @@ class RebuildVersionCache extends Maintenance {
 
 		$queue = array_fill_keys( array_merge(
 				glob( $this->getConfig()->get( 'ExtensionDirectory' ) . '/*/extension*.json' ),
-				glob( $this->getConfig()->get( 'ExtensionDirectory' ) . '/*/*/extension.json' ),
+				glob( $this->getConfig()->get( 'ExtensionDirectory' ) . '/SocialProfile/*/extension.json' ),
 				glob( $this->getConfig()->get( 'StyleDirectory' ) . '/*/skin.json' ),
 				glob( $this->getConfig()->get( 'StyleDirectory' ) . '/*/*/skin.json' )
 			),

--- a/maintenance/rebuildVersionCache.php
+++ b/maintenance/rebuildVersionCache.php
@@ -44,7 +44,7 @@ class RebuildVersionCache extends Maintenance {
 	public function execute() {
 		$blankConfig = new GlobalVarConfig( '' );
 
-		$gitInfo = new GitInfo( $blankConfig( 'IP' ), false );
+		$gitInfo = new GitInfo( $blankConfig->get( 'IP' ), false );
 		$gitInfo->precomputeValues();
 
 		$cache = ObjectCache::getInstance( CACHE_ANYTHING );

--- a/maintenance/rebuildVersionCache.php
+++ b/maintenance/rebuildVersionCache.php
@@ -51,10 +51,11 @@ class RebuildVersionCache extends Maintenance {
 		$coreId = $gitInfo->getHeadSHA1() ?: '';
 
 
-		global $wgExtensionDirectory,$wgStyleDirectory,$wgExtensionCredits;
 		$queue = array_fill_keys( array_merge(
-				glob( $wgExtensionDirectory . '/*/extension*.json' ),
-				glob( $wgStyleDirectory . '/*/skin.json' )
+				glob( $this->getConfig()->get( 'ExtensionDirectory' ) . '/*/extension*.json' ),
+				glob( $this->getConfig()->get( 'ExtensionDirectory' ) . '/*/*/extension.json' ),
+				glob( $this->getConfig()->get( 'StyleDirectory' ) . '/*/skin.json' ),
+				glob( $this->getConfig()->get( 'StyleDirectory' ) . '/*/*/skin.json' )
 			),
 		true );
 
@@ -71,7 +72,7 @@ class RebuildVersionCache extends Maintenance {
 		$data = $processor->getExtractedInfo();
 
 		$extensionCredits = array_merge( $data['credits'], array_values(
-				array_merge( ...array_values( $wgExtensionCredits ) )
+				array_merge( ...array_values( $this->getConfig()->get( 'ExtensionCredits' ) ) )
 			)
 		);
 


### PR DESCRIPTION
1) Supports ExtensionRegistry
2) Supports all extensions, even ones disabled on the specified wiki, since gitinfo cache is shared it should rebuild on all extensions and skins.

* ~~This may make this script work without the core hack from miraheze/mediawiki#2289.~~ It does not, but this is still needed.