### PR TITLE
RebuildVersionCache: drop the `--use-staging` argument

### DIFF
--- a/maintenance/rebuildVersionCache.php
+++ b/maintenance/rebuildVersionCache.php
@@ -42,17 +42,13 @@ class RebuildVersionCache extends Maintenance {
 		parent::__construct();
 		$this->addDescription( 'Rebuild the version cache' );
 		$this->addOption( 'save-gitinfo', 'Save gitinfo.json files' );
-		$this->addOption( 'use-staging', 'Use /srv/mediawiki-staging directory?' );
 	}
 
 	public function execute() {
 		global $IP, $wgShellRestrictionMethod;
 
+		$IP = '/srv/mediawiki-staging/w';
 		$wgShellRestrictionMethod = false;
-
-		if ( $this->hasOption( 'use-staging' ) ) {
-			$IP = '/srv/mediawiki-staging/w';
-		}
 
 		$gitInfo = new GitInfo( $IP, false );
 		$gitInfo->precomputeValues();


### PR DESCRIPTION
We use staging everywhere now.