### PR TITLE
Revert "reCAPTCHA: use globally not-blocked recaptcha.net instead of google.com"

### DIFF
--- a/ReCaptchaNoCaptcha/includes/ReCaptchaHtml.php
+++ b/ReCaptchaNoCaptcha/includes/ReCaptchaHtml.php
@@ -33,14 +33,14 @@ class ReCaptchaHtml {
 	public function headItem() {
 		if ( $this->version === 'v3' ) {
 			$script =
-				"<script src=\"https://www.recaptcha.net/recaptcha/api.js?render=$this->siteKey\"></script>" .
+				"<script src=\"https://www.google.com/recaptcha/api.js?render=$this->siteKey\"></script>" .
 				$this->v3Script();
 		} else {
 			// Insert reCAPTCHA script, in display language, if available.
 			// Language falls back to the browser's display language.
 			// See https://developers.google.com/recaptcha/docs/faq
 			$script =
-				"<script src=\"https://www.recaptcha.net/recaptcha/api.js?hl={$this->languageCode}\"" .
+				"<script src=\"https://www.google.com/recaptcha/api.js?hl={$this->languageCode}\"" .
 				"async defer></script>";
 		}
 
@@ -78,7 +78,7 @@ HTML;
     <div style="width: 302px; height: 422px; position: relative;">
       <div style="width: 302px; height: 422px; position: absolute;">
         <iframe src=
-        "https://www.recaptcha.net/recaptcha/api/fallback?k={$htmlUrlencoded}&hl={$this->languageCode}"
+        "https://www.google.com/recaptcha/api/fallback?k={$htmlUrlencoded}&hl={$this->languageCode}"
         frameborder="0" scrolling="no" style="width: 302px;height:422px; border-style: none;">
         </iframe>
       </div>

--- a/ReCaptchaNoCaptcha/includes/ReCaptchaNoCaptcha.php
+++ b/ReCaptchaNoCaptcha/includes/ReCaptchaNoCaptcha.php
@@ -76,7 +76,7 @@ class ReCaptchaNoCaptcha extends SimpleCaptcha {
 	protected function passCaptcha( $_, $word ) {
 		global $wgRequest, $wgReCaptchaSecretKey, $wgReCaptchaSendRemoteIP, $wgReCaptchaVersion, $wgReCaptchaMinimumScore;
 
-		$url = 'https://www.recaptcha.net/recaptcha/api/siteverify';
+		$url = 'https://www.google.com/recaptcha/api/siteverify';
 		// Build data to append to request
 		$data = [
 			'secret' => $wgReCaptchaSecretKey,

--- a/ReCaptchaNoCaptcha/includes/ReCaptchaNoCaptchaHooks.php
+++ b/ReCaptchaNoCaptcha/includes/ReCaptchaNoCaptchaHooks.php
@@ -25,7 +25,7 @@ class ReCaptchaNoCaptchaHooks {
 		if ( $wgCaptchaClass === 'ReCaptchaNoCaptcha' ) {
 			$vars['wgConfirmEditConfig'] = [
 				'reCaptchaSiteKey' => $wgReCaptchaSiteKey,
-				'reCaptchaScriptURL' => 'https://www.recaptcha.net/recaptcha/api.js'
+				'reCaptchaScriptURL' => 'https://www.google.com/recaptcha/api.js'
 			];
 		}
 


### PR DESCRIPTION
Reverts miraheze/MirahezeMagic#300

recaptcha.net does not work.

We should only fall back if google is broken and not returning a response, maybe we can use v2 in China only?