### PR TITLE
Add group member interface message for the member group

### DIFF
--- a/i18n/miraheze/en.json
+++ b/i18n/miraheze/en.json
@@ -134,7 +134,7 @@
 	"group-global-ipblock-exempt-member": "{{GENDER:$1|global IP block exempt}}",
 	"grouppage-global-ipblock-exempt": "m:Global IP block exemption",
 	"group-member": "Members",
- 	"group-member-member": "member",
+ 	"group-member-member": "{{GENDER:$1|member}}",
 	"protect-level-user": "Allow only logged in users",
 	"restriction-delete": "Delete",
 	"restriction-level-user": "Allow only logged in users",

--- a/i18n/miraheze/en.json
+++ b/i18n/miraheze/en.json
@@ -134,6 +134,7 @@
 	"group-global-ipblock-exempt-member": "{{GENDER:$1|global IP block exempt}}",
 	"grouppage-global-ipblock-exempt": "m:Global IP block exemption",
 	"group-member": "Members",
+ 	"group-member-member": "member",
 	"protect-level-user": "Allow only logged in users",
 	"restriction-delete": "Delete",
 	"restriction-level-user": "Allow only logged in users",

--- a/i18n/miraheze/qqq.json
+++ b/i18n/miraheze/qqq.json
@@ -70,7 +70,7 @@
 	"group-global-ipblock-exempt": "Global IP block exemptions",
 	"group-global-ipblock-exempt-member": "{{GENDER:$1|global IP block exempt}}",
 	"group-member": "Members\n\n{{Identical|Member}}",
-	"group-member-member": "member",
+	"group-member-member": "member\n\n{{Identical|Member}}",
 	"protect-level-user": "Allow only logged in users",
 	"restriction-delete": "Delete\n{{Identical|Delete}}",
 	"restriction-level-user": "Allow only logged in users",

--- a/i18n/miraheze/qqq.json
+++ b/i18n/miraheze/qqq.json
@@ -70,6 +70,7 @@
 	"group-global-ipblock-exempt": "Global IP block exemptions",
 	"group-global-ipblock-exempt-member": "{{GENDER:$1|global IP block exempt}}",
 	"group-member": "Members\n\n{{Identical|Member}}",
+	"group-member-member": "member",
 	"protect-level-user": "Allow only logged in users",
 	"restriction-delete": "Delete\n{{Identical|Delete}}",
 	"restriction-level-user": "Allow only logged in users",


### PR DESCRIPTION
Required because of more contemporary changes to the Navigation Popups gadget on English Wikipedia that uses localised group names, rather than technical group names. I started a discussion to possibly revert the change (https://en.wikipedia.org/w/index.php?title=MediaWiki_talk:Gadget-popups.js&oldid=1055257786#Question_about_possible_recently_deployed_changes_to_Navigation_Popups_gadget), but it seems unlikely to pass

I know I need to do the `qqq.json` part, @Universal-Omega 