### PR TITLE
remove 'miraheze-group' for non-global roles

### DIFF
--- a/i18n/overrides/en.json
+++ b/i18n/overrides/en.json
@@ -25,17 +25,7 @@
 	"miraheze-group-checkuser": "Checkusers",
 	"miraheze-group-checkuser-member": "checkuser",
 	"miraheze-grouppage-checkuser": "m:Special:MyLanguage/CheckUser",
-	"miraheze-group-bureaucrat": "Bureaucrats",
-	"miraheze-grouppage-bureaucrat": "m:Special:MyLanguage/User groups#{{int:Group-bureaucrat}}",
-	"miraheze-group-bureaucrat-member": "{{GENDER:$1|bureaucrat}}",
-	"miraheze-group-sysop": "Administrators",
-	"miraheze-grouppage-sysop": "m:Special:MyLanguage/User groups#{{int:Group-sysop}}",
-	"miraheze-group-sysop-member": "{{GENDER:$1|administrator}}",
 	"miraheze-group-interface-admin": "Interface administrators",
 	"miraheze-grouppage-interface-admin": "m:Special:MyLanguage/User groups#{{int:Group-interface-admin}}",
 	"miraheze-group-interface-admin-member": "{{GENDER:$1|interface administrator}}",
-	"miraheze-group-bot": "Bots",
-	"miraheze-grouppage-bot": "m:Special:MyLanguage/User groups#{{int:Group-bot}}",
-	"miraheze-group-bot-member": "{{GENDER:$1|bot}}",
-	"miraheze-grouppage-user": "m:Special:MyLanguage/User groups#{{int:Group-user}}"
 }

--- a/i18n/overrides/en.json
+++ b/i18n/overrides/en.json
@@ -27,5 +27,5 @@
 	"miraheze-grouppage-checkuser": "m:Special:MyLanguage/CheckUser",
 	"miraheze-group-interface-admin": "Interface administrators",
 	"miraheze-grouppage-interface-admin": "m:Special:MyLanguage/User groups#{{int:Group-interface-admin}}",
-	"miraheze-group-interface-admin-member": "{{GENDER:$1|interface administrator}}",
+	"miraheze-group-interface-admin-member": "{{GENDER:$1|interface administrator}}"
 }

--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -184,19 +184,9 @@ class MirahezeMagicHooks {
 			'group-checkuser',
 			'group-checkuser-member',
 			'grouppage-checkuser',
-			'group-bureaucrat',
-			'grouppage-bureaucrat',
-			'group-bureaucrat-member',
-			'group-sysop',
-			'grouppage-sysop',
-			'group-sysop-member',
 			'group-interface-admin',
 			'grouppage-interface-admin',
 			'group-interface-admin-member',
-			'group-bot',
-			'grouppage-bot',
-			'group-bot-member',
-			'grouppage-user',
 		];
 
 		if ( in_array( $lcKey, $keys, true ) ) {


### PR DESCRIPTION
Not sure why such definitions are needed globally for non-global roles. (Especially since they are just the defaults and they can be altered with ManageWiki). It should also fix https://phabricator.miraheze.org/T8667 ?