### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/mediawiki-tests.yml
+++ b/.github/workflows/mediawiki-tests.yml
@@ -52,7 +52,7 @@ jobs:
           - mw: 'master'
             php: 7.4
             php-docker: 74
-            experimental: false
+            experimental: true
             stage: phpunit
 
           # Latest stable MediaWiki - PHP 7.4 (selenium)


### PR DESCRIPTION
This sets the phpunit build against MediaWiki master as experimental meaning that the specific build will not cause an overall failure. I believe our focus is compatibility with MediaWiki stable, and that doesn’t necessarily mean compatibility with master.