### PR TITLE
use CW config variables for SiteNoticeAfter --

### DIFF
--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -432,17 +432,16 @@ class MirahezeMagicHooks {
 	}
 
 	public static function onSiteNoticeAfter( &$siteNotice, $skin ) {
-		$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'mirahezemagic' );
-		$wiki = new RemoteWiki( $config->get( 'DBname' ) );
+		$cwConfig = new GlobalVarConfig( 'cw' );
 
-		if ( $wiki->isClosed() ) {
-			if ( $wiki->isPrivate() ) {
+		if ( $cwConfig->get( 'Closed' ) ) {
+			if ( $cwConfig->get( 'Private' ) ) {
 				$siteNotice .= '<div class="wikitable" style="text-align: center; width: 90%; margin-left: auto; margin-right:auto; padding: 15px; border: 4px solid black; background-color: #EEE;"> <span class="plainlinks"> <img src="https://static.miraheze.org/metawiki/0/02/Wiki_lock.png" align="left" style="width:80px;height:90px;">' . $skin->msg( 'miraheze-sitenotice-closed-private' )->parse() . '</span></div>';
 			} else {
 				$siteNotice .= '<div class="wikitable" style="text-align: center; width: 90%; margin-left: auto; margin-right:auto; padding: 15px; border: 4px solid black; background-color: #EEE;"> <span class="plainlinks"> <img src="https://static.miraheze.org/metawiki/0/02/Wiki_lock.png" align="left" style="width:80px;height:90px;">' . $skin->msg( 'miraheze-sitenotice-closed' )->parse() . '</span></div>';
 			}
-		} elseif ( $wiki->isInactive() && !$wiki->isInactiveExempt() ) {
-			if ( $wiki->isPrivate() ) {
+		} elseif ( $cwConfig->get( 'Inactive' ) && $cwConfig->get( 'Inactive' ) !== 'exempt' ) {
+			if ( $cwConfig->get( 'Private' ) ) {
 				$siteNotice .= '<div class="wikitable" style="text-align: center; width: 90%; margin-left: auto; margin-right:auto; padding: 15px; border: 4px solid black; background-color: #EEE;"> <span class="plainlinks"> <img src="https://static.miraheze.org/metawiki/5/5f/Out_of_date_clock_icon.png" align="left" style="width:80px;height:90px;">' . $skin->msg( 'miraheze-sitenotice-inactive-private' )->parse() . '</span></div>';
 			} else {
 				$siteNotice .= '<div class="wikitable" style="text-align: center; width: 90%; margin-left: auto; margin-right:auto; padding: 15px; border: 4px solid black; background-color: #EEE;"> <span class="plainlinks"> <img src="https://static.miraheze.org/metawiki/5/5f/Out_of_date_clock_icon.png" align="left" style="width:80px;height:90px;">' . $skin->msg( 'miraheze-sitenotice-inactive' )->parse() . '</span></div>';


### PR DESCRIPTION
Always using database on every page load causes connection timed out errors.

Evidenced by:
```
mediawiki_error
:real_connect(): (HY000/2002): Connection timed out
```

With the following being the part of the stack trace that leads to error:
```
#9 /srv/mediawiki/w/extensions/CreateWiki/includes/RemoteWiki.php(34): wfGetDB(integer, array, string)
#10 /srv/mediawiki/w/extensions/MirahezeMagic/includes/MirahezeMagicHooks.php(436): Miraheze\CreateWiki\RemoteWiki->__construct(string)
#11 /srv/mediawiki/w/includes/HookContainer/HookContainer.php(338): MirahezeMagicHooks::onSiteNoticeAfter(string, SkinVector)
```