### PR TITLE
Fix read/write acl on renamed containers

### DIFF
--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -144,6 +144,9 @@ class MirahezeMagicHooks {
 			)
 		);
 
+		$remoteWiki = new RemoteWiki( $new );
+		$isPrivate = $wiki->isPrivate();
+
 		foreach ( $containers as $container ) {
 			// Just an extra precaution to ensure we don't select the wrong containers
 			if ( !str_contains( $container, $old . '-' ) ) {
@@ -200,8 +203,8 @@ class MirahezeMagicHooks {
 				implode( ' ', [
 					'swift', 'upload',
 					$newContainer,
-					'--read-acl', 'mw:media,mw:media,.r:*',
-					'--write-acl', 'mw:media,mw:media',
+					'--read-acl', $isPrivate ? 'mw:media' : 'mw:media,mw:media,.r:*',
+					'--write-acl', $isPrivate ? 'mw:media' : 'mw:media,mw:media',
 					'-A', 'https://swift-lb.miraheze.org/auth/v1.0',
 					'-U', 'mw:media',
 					'-K', $wmgSwiftPassword


### PR DESCRIPTION
We call out to setContainersAccess which calls ->prepare. But within that function it checks if a container exists already and if it does, it does nothing. So no permissions are changed.

We fix this by manually setting each container that is renamed to use the correct acts.

Even so that maintenance script only did the core containers (no extension containers).