### PR TITLE
Add a warning regarding where to register the authenticator

### DIFF
--- a/i18n/overrides/en.json
+++ b/i18n/overrides/en.json
@@ -45,5 +45,6 @@
 	"miraheze-group-bot": "Bots",
 	"miraheze-grouppage-bot": "m:Special:MyLanguage/User groups#{{int:Group-bot}}",
 	"miraheze-group-bot-member": "{{GENDER:$1|bot}}",
-	"miraheze-grouppage-user": "m:Special:MyLanguage/User groups#{{int:Group-user}}"
+	"miraheze-grouppage-user": "m:Special:MyLanguage/User groups#{{int:Group-user}}",
+	"miraheze-webauthn-module-description": "WebAuthn (Web Authentication) is a web standard published by the World Wide Web Consortium (W3C). WebAuthn is a core component of the FIDO2 Project under the guidance of the FIDO Alliance. The goal of the project is to standardize an interface for authenticating users to web-based applications and services using public-key cryptography. [https://en.wikipedia.org/wiki/WebAuthn Read more] <br> '''Please keep in mind that you'll have to go to the wiki you registered the authenticator on to log-in'''. You may want to register the authenticator on [[mh:meta|Meta]] for this reason."
 }

--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -347,6 +347,7 @@ class MirahezeMagicHooks {
 			'grouppage-bot',
 			'group-bot-member',
 			'grouppage-user',
+			'webauthn-module-description',
 		];
 
 		if ( in_array( $lcKey, $keys, true ) ) {


### PR DESCRIPTION
WebAuthn authenticators only work on the specific domain where they were registered. So, registering it on for example avid.miraheze.org, one may find themselves surprised that they are not able to log-in at Meta if they don't know how WebAuthn works.

Like in Wikimedia, we may want to warn users regarding this behavior. Once logged in on the wiki where they registered the authenticator, CentralAuth should take care of the rest and log them in on all the various wikis as they browse.