### PR TITLE
rebuildVersionCache: Use MW_INSTALL_PATH instead of wgBaseDirectory

### DIFF
--- a/maintenance/rebuildVersionCache.php
+++ b/maintenance/rebuildVersionCache.php
@@ -143,7 +143,7 @@ class RebuildVersionCache extends Maintenance {
 			$gitInfoCacheDirectory = $this->getConfig()->get( 'CacheDirectory' ) . '/gitinfo';
 		}
 
-		$baseDir = $this->getConfig()->get( 'BaseDirectory' );
+		$baseDir = MW_INSTALL_PATH;
 
 		if ( $gitInfoCacheDirectory ) {
 			// Convert both MW_INSTALL_PATH and $repoDir to canonical paths to protect against


### PR DESCRIPTION
wgBaseDirectory was added in core as a temporary alternative to the non-wg prefixed `$IP` but in practice neither is preferred given the MW_INSTALL_PATH constant.

Use it here as well, matching other parts of the same file that use it here already.