### PR TITLE
Don't trigger Status::newFatal( 'centralauth-rename-notinstalled' ) on mw 1.40+

### DIFF
--- a/includes/SpecialVanishUser.php
+++ b/includes/SpecialVanishUser.php
@@ -115,7 +115,7 @@ class SpecialVanishUser extends FormSpecialPage {
 			return Status::newFatal( 'removepii-centralauth-notinstalled' );
 		}
 
-		if ( !ExtensionRegistry::getInstance()->isLoaded( 'Renameuser' ) ) {
+		if ( version_compare( MW_VERSION, '1.40', '<' ) && !ExtensionRegistry::getInstance()->isLoaded( 'Renameuser' ) ) {
 			return Status::newFatal( 'centralauth-rename-notinstalled' );
 		}
 

--- a/includes/SpecialVanishUser.php
+++ b/includes/SpecialVanishUser.php
@@ -115,7 +115,9 @@ class SpecialVanishUser extends FormSpecialPage {
 			return Status::newFatal( 'removepii-centralauth-notinstalled' );
 		}
 
-		if ( version_compare( MW_VERSION, '1.40', '<' ) && !ExtensionRegistry::getInstance()->isLoaded( 'Renameuser' ) ) {
+		if ( version_compare( MW_VERSION, '1.40', '<' ) &&
+		    !ExtensionRegistry::getInstance()->isLoaded( 'Renameuser' )
+		) {
 			return Status::newFatal( 'centralauth-rename-notinstalled' );
 		}
 

--- a/includes/SpecialVanishUser.php
+++ b/includes/SpecialVanishUser.php
@@ -116,7 +116,7 @@ class SpecialVanishUser extends FormSpecialPage {
 		}
 
 		if ( version_compare( MW_VERSION, '1.40', '<' ) &&
-		    !ExtensionRegistry::getInstance()->isLoaded( 'Renameuser' )
+			!ExtensionRegistry::getInstance()->isLoaded( 'Renameuser' )
 		) {
 			return Status::newFatal( 'centralauth-rename-notinstalled' );
 		}


### PR DESCRIPTION
Renameuser is now bundled into core and thus the extension is of no use.