### PR TITLE
Use run.php on MW 1.40+ to run scripts

### DIFF
--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -233,11 +233,17 @@ class MirahezeMagicHooks {
 			}
 		}
 
+		$scriptOptions = [];
+		if ( version_compare( MW_VERSION, '1.40', '>=' ) ) {
+			$scriptOptions = [ 'wrapper' => MW_INSTALL_PATH . '/maintenance/run.php' ];
+		}
+
 		Shell::makeScriptCommand(
 			MW_INSTALL_PATH . '/extensions/CreateWiki/maintenance/setContainersAccess.php',
 			[
 				'--wiki', $new
-			]
+			],
+			$scriptOptions
 		)->limits( $limits )->execute();
 
 		static::removeRedisKey( "*{$old}*" );


### PR DESCRIPTION
Using scripts directly is deprecated as of MW 1.40. You have to use them with run.php.