### PR TITLE
Remove use of GlobalUserPageWikis hook

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -108,9 +108,6 @@
 		"InitializeArticleMaybeRedirect": [
 			"MirahezeMagicHooks::onInitializeArticleMaybeRedirect"
 		],
-		"GlobalUserPageWikis": [
-			"MirahezeMagicHooks::onGlobalUserPageWikis"
-		],
 		"MimeMagicInit": [
 			"MirahezeMagicHooks::onMimeMagicInit"
 		],

--- a/includes/MirahezeMagicHooks.php
+++ b/includes/MirahezeMagicHooks.php
@@ -498,19 +498,6 @@ class MirahezeMagicHooks {
 		}
 	}
 
-	public static function onGlobalUserPageWikis( &$list ) {
-		$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'mirahezemagic' );
-		$cwCacheDir = $config->get( 'CreateWikiCacheDirectory' );
-		if ( file_exists( "{$cwCacheDir}/databases.json" ) ) {
-			$databaseFile = file_get_contents( "{$cwCacheDir}/databases.json" );
-			$databasesArray = json_decode( $databaseFile, true );
-			$list = array_keys( $databasesArray['combi'] );
-			return false;
-		}
-
-		return true;
-	}
-
 	/** Removes redis keys for jobrunner */
 	public static function removeRedisKey( string $key ) {
 		global $wgJobTypeConf;


### PR DESCRIPTION
We already set wgLocalDatabases and if on the cli delete- is added. Prevents jobs not being able to be executed and thus stay.