### PR TITLE
Improve the message managewiki-setting-wgAllowSlowParserFunctions-help

### DIFF
--- a/i18n/managewiki/en.json
+++ b/i18n/managewiki/en.json
@@ -72,7 +72,7 @@
 	"managewiki-setting-wgVisualEditorUseSingleEditTab-name": "VisualEditor Use Single Edit Tab",
 	"managewiki-setting-wgVisualEditorUseSingleEditTab-help": "Shows only the \"edit\" tab. Uses VisualEditor by default if \"Make VisualEditor the default editor for all\" is set, otherwise defaults to wikitext.",
 	"managewiki-setting-wgAllowSlowParserFunctions-name": "Allow slow parser functions",
-	"managewiki-setting-wgAllowSlowParserFunctions-help": "Parser functions are \"magic words\" that return a value or function, such as time, site details, or page names.",
+	"managewiki-setting-wgAllowSlowParserFunctions-help": "Parser functions are \"magic words\" that return a value such as time, site details, or page names.",
 	"managewiki-setting-wgPFEnableStringFunctions-name": "Enable string function functionality",
 	"managewiki-setting-wgPFEnableStringFunctions-help": "This option adds support a couple of functions for basic string handling. Example: #pos function returns the position of a given search term within the string. You can learn more in MediaWiki's documentation page https://www.mediawiki.org/wiki/Module:String.",
 	"managewiki-setting-wmgAllowEntityImport-name": "Allow Entity Import (Wikibase)",


### PR DESCRIPTION
The word "function" is already mentioned,
and those magic words return wikitext and
not other functions
(it's just wikitext and not JavaScript ;).