### PR TITLE
Pretty Print JSON result

### DIFF
--- a/maintenance/generateExtensionDatabaseList.php
+++ b/maintenance/generateExtensionDatabaseList.php
@@ -48,7 +48,7 @@ class GenerateExtensionDatabaseList extends Maintenance {
 
 		$directory = $this->getOption( 'directory' );
 		foreach ( $extArray as $ext ) {
-			file_put_contents( "{$directory}/{$ext}.json", json_encode( [ 'combi' => $lists[$ext] ] ), LOCK_EX );
+			file_put_contents( "{$directory}/{$ext}.json", json_encode( [ 'combi' => $lists[$ext] ], JSON_PRETTY_PRINT ), LOCK_EX );
 		}
 	}
 }


### PR DESCRIPTION
The result of this script is pretty useless as it is if we want to count the number of wikis that use an extension quickly because at current its all on one line. 

This pretty prints it using JSON_PRETTY_PRINT so the result can be piped to wc -l