### PR TITLE
Temporarily remove CreateWiki hook interfaces

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -33,12 +33,6 @@ use MediaWiki\User\User;
 use MediaWiki\WikiMap\WikiMap;
 use Memcached;
 use MessageCache;
-use Miraheze\CreateWiki\Hooks\CreateWikiDeletionHook;
-use Miraheze\CreateWiki\Hooks\CreateWikiReadPersistentModelHook;
-use Miraheze\CreateWiki\Hooks\CreateWikiRenameHook;
-use Miraheze\CreateWiki\Hooks\CreateWikiStatePrivateHook;
-use Miraheze\CreateWiki\Hooks\CreateWikiTablesHook;
-use Miraheze\CreateWiki\Hooks\CreateWikiWritePersistentModelHook;
 use Miraheze\ImportDump\Hooks\ImportDumpJobAfterImportHook;
 use Miraheze\ImportDump\Hooks\ImportDumpJobGetFileHook;
 use Miraheze\ManageWiki\Helpers\ManageWikiSettings;
@@ -52,12 +46,6 @@ class Hooks implements
 	AbuseFilterShouldFilterActionHook,
 	BlockIpCompleteHook,
 	ContributionsToolLinksHook,
-	CreateWikiDeletionHook,
-	CreateWikiReadPersistentModelHook,
-	CreateWikiRenameHook,
-	CreateWikiStatePrivateHook,
-	CreateWikiTablesHook,
-	CreateWikiWritePersistentModelHook,
 	GetLocalURL__InternalHook,
 	ImportDumpJobAfterImportHook,
 	ImportDumpJobGetFileHook,


### PR DESCRIPTION
The signatures will change (type hinting) and we don't want to go down in the process so lets remove the interfaces for now.