### PR TITLE
Cleanup/modernize maintenance scripts

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -33,20 +33,21 @@
 		"MirahezeMagicAliases": "MirahezeMagicAliases.php"
 	},
 	"AutoloadNamespaces": {
-		"Miraheze\\MirahezeMagic\\": "includes/"
+		"Miraheze\\MirahezeMagic\\": "includes/",
+		"Miraheze\\MirahezeMagic\\Maintenance\\": "maintenance/"
 	},
-        "LogActionsHandlers": {
-                "vanishuser/*": "LogFormatter"
-        },
-        "LogHeaders": {
-                "vanishuser": "vanishuser-log-header"
-        },
-        "LogNames": {
-                "vanishuser": "vanishuser-log-name"
-        },
-        "LogTypes": [
-                "vanishuser"
-        ],
+	"LogActionsHandlers": {
+		"vanishuser/*": "LogFormatter"
+	},
+	"LogHeaders": {
+		"vanishuser": "vanishuser-log-header"
+	},
+	"LogNames": {
+		"vanishuser": "vanishuser-log-name"
+	},
+	"LogTypes": [
+		"vanishuser"
+	],
 	"SpecialPages": {
 		"VanishUser": {
 			"class": "Miraheze\\MirahezeMagic\\Specials\\SpecialVanishUser",

--- a/maintenance/AssignImportedEdits.php
+++ b/maintenance/AssignImportedEdits.php
@@ -27,13 +27,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 4.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 
 class AssignImportedEdits extends Maintenance {
@@ -223,5 +216,6 @@ class AssignImportedEdits extends Maintenance {
 	}
 }
 
-$maintClass = AssignImportedEdits::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return AssignImportedEdits::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/ChangeMediaWikiVersion.php
+++ b/maintenance/ChangeMediaWikiVersion.php
@@ -24,13 +24,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\Maintenance;
 use MirahezeFunctions;
@@ -100,5 +93,6 @@ class ChangeMediaWikiVersion extends Maintenance {
 	}
 }
 
-$maintClass = ChangeMediaWikiVersion::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return ChangeMediaWikiVersion::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/CheckSwiftContainers.php
+++ b/maintenance/CheckSwiftContainers.php
@@ -24,13 +24,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 use MediaWiki\Shell\Shell;
 
@@ -206,5 +199,6 @@ class CheckSwiftContainers extends Maintenance {
 	}
 }
 
-$maintClass = CheckSwiftContainers::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return CheckSwiftContainers::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/CheckWikiDatabases.php
+++ b/maintenance/CheckWikiDatabases.php
@@ -24,13 +24,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 use Wikimedia\Rdbms\ILoadBalancer;
 
@@ -248,5 +241,6 @@ class CheckWikiDatabases extends Maintenance {
 	}
 }
 
-$maintClass = CheckWikiDatabases::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return CheckWikiDatabases::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/CreateCargoDB.php
+++ b/maintenance/CreateCargoDB.php
@@ -24,13 +24,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use Exception;
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\Maintenance;
@@ -61,5 +54,6 @@ class CreateCargoDB extends Maintenance {
 	}
 }
 
-$maintClass = CreateCargoDB::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return CreateCargoDB::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/CreateUsers.php
+++ b/maintenance/CreateUsers.php
@@ -26,13 +26,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Extension\CentralAuth\User\CentralAuthUser;
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\Maintenance;
@@ -112,5 +105,6 @@ class CreateUsers extends Maintenance {
 	}
 }
 
-$maintClass = CreateUsers::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return CreateUsers::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/FindPossibleUpgradeScripts.php
+++ b/maintenance/FindPossibleUpgradeScripts.php
@@ -29,13 +29,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 
 class FindPossibleUpgradeScripts extends Maintenance {
@@ -122,5 +115,6 @@ class FindPossibleUpgradeScripts extends Maintenance {
 	}
 }
 
-$maintClass = FindPossibleUpgradeScripts::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return FindPossibleUpgradeScripts::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/FindSQLPatches.php
+++ b/maintenance/FindSQLPatches.php
@@ -29,13 +29,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 
 class FindSQLPatches extends Maintenance {
@@ -113,5 +106,6 @@ class FindSQLPatches extends Maintenance {
 	}
 }
 
-$maintClass = FindSQLPatches::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return FindSQLPatches::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/FixImageUser.php
+++ b/maintenance/FixImageUser.php
@@ -24,13 +24,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 use MediaWiki\User\User;
 
@@ -119,5 +112,6 @@ class FixImageUser extends Maintenance {
 	}
 }
 
-$maintClass = FixImageUser::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return FixImageUser::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/FixUserIdLogging.php
+++ b/maintenance/FixUserIdLogging.php
@@ -25,13 +25,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 use Wikimedia\AtEase\AtEase;
 
@@ -176,5 +169,6 @@ class FixUserIdLogging extends Maintenance {
 	}
 }
 
-$maintClass = FixUserIdLogging::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return FixUserIdLogging::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/FixUserIdRevision.php
+++ b/maintenance/FixUserIdRevision.php
@@ -24,13 +24,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 
 class FixUserIdRevision extends Maintenance {
@@ -159,5 +152,6 @@ class FixUserIdRevision extends Maintenance {
 	}
 }
 
-$maintClass = FixUserIdRevision::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return FixUserIdRevision::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/GenerateExtensionDatabaseList.php
+++ b/maintenance/GenerateExtensionDatabaseList.php
@@ -2,13 +2,6 @@
 
 namespace Miraheze\MirahezeMagic\Maintenance;
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 
 class GenerateExtensionDatabaseList extends Maintenance {
@@ -65,5 +58,6 @@ class GenerateExtensionDatabaseList extends Maintenance {
 	}
 }
 
-$maintClass = GenerateExtensionDatabaseList::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return GenerateExtensionDatabaseList::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/GenerateManageWikiBackup.php
+++ b/maintenance/GenerateManageWikiBackup.php
@@ -24,13 +24,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\Maintenance;
 
@@ -126,5 +119,6 @@ class GenerateManageWikiBackup extends Maintenance {
 	}
 }
 
-$maintClass = GenerateManageWikiBackup::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return GenerateManageWikiBackup::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/GenerateMirahezeSitemap.php
+++ b/maintenance/GenerateMirahezeSitemap.php
@@ -25,13 +25,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 2.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use GenerateSitemap;
 use MediaWiki\Context\RequestContext;
 use MediaWiki\MainConfigNames;
@@ -128,5 +121,6 @@ class GenerateMirahezeSitemap extends Maintenance {
 	}
 }
 
-$maintClass = GenerateMirahezeSitemap::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return GenerateMirahezeSitemap::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/GetSiteInfo.php
+++ b/maintenance/GetSiteInfo.php
@@ -2,13 +2,6 @@
 
 namespace Miraheze\MirahezeMagic\Maintenance;
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\Maintenance;
 
@@ -30,5 +23,6 @@ class GetSiteInfo extends Maintenance {
 	}
 }
 
-$maintClass = GetSiteInfo::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return GetSiteInfo::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/InsertMissingLocalUserRows.php
+++ b/maintenance/InsertMissingLocalUserRows.php
@@ -24,13 +24,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Extension\CentralAuth\User\CentralAuthUser;
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\Maintenance;
@@ -107,5 +100,6 @@ class InsertMissingLocalUserRows extends Maintenance {
 	}
 }
 
-$maintClass = InsertMissingLocalUserRows::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return InsertMissingLocalUserRows::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/MergeMessageFileList.php
+++ b/maintenance/MergeMessageFileList.php
@@ -27,13 +27,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
 
 define( 'MW_NO_EXTENSION_MESSAGES', 1 );
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 # Start from scratch
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\Maintenance;
@@ -243,5 +236,6 @@ class MergeMessageFileList extends Maintenance {
 	}
 }
 
-$maintClass = MergeMessageFileList::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return MergeMessageFileList::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/MigrateSearchIndexSql.php
+++ b/maintenance/MigrateSearchIndexSql.php
@@ -24,13 +24,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use Exception;
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\Maintenance;
@@ -68,5 +61,6 @@ class MigrateSearchIndexSql extends Maintenance {
 	}
 }
 
-$maintClass = MigrateSearchIndexSql::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return MigrateSearchIndexSql::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/PopulateWikibaseSitesTable.php
+++ b/maintenance/PopulateWikibaseSitesTable.php
@@ -25,13 +25,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use Exception;
 use MediaWiki\Maintenance\Maintenance;
 use MediaWiki\Site\MediaWikiSite;
@@ -193,5 +186,6 @@ class PopulateWikibaseSitesTable extends Maintenance {
 	}
 }
 
-$maintClass = PopulateWikibaseSitesTable::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return PopulateWikibaseSitesTable::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/RebuildVersionCache.php
+++ b/maintenance/RebuildVersionCache.php
@@ -30,13 +30,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 3.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Config\HashConfig;
 use MediaWiki\Json\FormatJson;
 use MediaWiki\MainConfigNames;
@@ -218,5 +211,6 @@ class RebuildVersionCache extends Maintenance {
 	}
 }
 
-$maintClass = RebuildVersionCache::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return RebuildVersionCache::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/RenameDatabase.php
+++ b/maintenance/RenameDatabase.php
@@ -24,13 +24,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 use Wikimedia\Rdbms\ILoadBalancer;
 
@@ -151,5 +144,6 @@ class RenameDatabase extends Maintenance {
 	}
 }
 
-$maintClass = RenameDatabase::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return RenameDatabase::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/ReplaceTextEligible.php
+++ b/maintenance/ReplaceTextEligible.php
@@ -24,13 +24,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 use Wikimedia\Rdbms\IExpression;
 use Wikimedia\Rdbms\LikeValue;
@@ -153,5 +146,6 @@ class ReplaceTextEligible extends Maintenance {
 	}
 }
 
-$maintClass = ReplaceTextEligible::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return ReplaceTextEligible::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/ResetWiki.php
+++ b/maintenance/ResetWiki.php
@@ -24,13 +24,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\Maintenance\Maintenance;
 use Wikimedia\Rdbms\ILoadBalancer;
 
@@ -140,5 +133,6 @@ class ResetWiki extends Maintenance {
 	}
 }
 
-$maintClass = ResetWiki::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return ResetWiki::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/ResetWikiCaches.php
+++ b/maintenance/ResetWikiCaches.php
@@ -2,13 +2,6 @@
 
 namespace Miraheze\MirahezeMagic\Maintenance;
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\Maintenance;
 
@@ -29,5 +22,6 @@ class ResetWikiCaches extends Maintenance {
 	}
 }
 
-$maintClass = ResetWikiCaches::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return ResetWikiCaches::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/RestoreManageWikiBackup.php
+++ b/maintenance/RestoreManageWikiBackup.php
@@ -24,13 +24,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @version 1.0
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\Maintenance;
 use Miraheze\ManageWiki\Helpers\ManageWikiExtensions;
@@ -151,5 +144,6 @@ class RestoreManageWikiBackup extends Maintenance {
 	}
 }
 
-$maintClass = RestoreManageWikiBackup::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return RestoreManageWikiBackup::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/SendBulkEmails.php
+++ b/maintenance/SendBulkEmails.php
@@ -23,13 +23,6 @@ namespace Miraheze\MirahezeMagic\Maintenance;
  * @ingroup Wikimedia
  */
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MailAddress;
 use MediaWiki\Content\TextContent;
 use MediaWiki\Context\RequestContext;
@@ -421,5 +414,6 @@ class SendBulkEmails extends Maintenance {
 	}
 }
 
-$maintClass = SendBulkEmails::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return SendBulkEmails::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/SwiftDump.php
+++ b/maintenance/SwiftDump.php
@@ -2,13 +2,6 @@
 
 namespace Miraheze\MirahezeMagic\Maintenance;
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\Maintenance;
 use MediaWiki\Shell\Shell;
@@ -108,5 +101,6 @@ class SwiftDump extends Maintenance {
 	}
 }
 
-$maintClass = SwiftDump::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return SwiftDump::class;
+// @codeCoverageIgnoreEnd

--- a/maintenance/UpdatePrivateAuthUrls.php
+++ b/maintenance/UpdatePrivateAuthUrls.php
@@ -2,13 +2,6 @@
 
 namespace Miraheze\MirahezeMagic\Maintenance;
 
-$IP = getenv( 'MW_INSTALL_PATH' );
-if ( $IP === false ) {
-	$IP = __DIR__ . '/../../..';
-}
-
-require_once "$IP/maintenance/Maintenance.php";
-
 use MediaWiki\MainConfigNames;
 use MediaWiki\Maintenance\Maintenance;
 use Miraheze\ManageWiki\Helpers\ManageWikiSettings;
@@ -40,5 +33,6 @@ class UpdatePrivateAuthUrls extends Maintenance {
 	}
 }
 
-$maintClass = UpdatePrivateAuthUrls::class;
-require_once RUN_MAINTENANCE_IF_MAIN;
+// @codeCoverageIgnoreStart
+return UpdatePrivateAuthUrls::class;
+// @codeCoverageIgnoreEnd


### PR DESCRIPTION
### Maintenance Scripts Now Require `run.php`

Maintenance scripts **can no longer be run directly** by passing them to the PHP interpreter. Instead, they now **require** `run.php`.

#### New Usage:
Scripts can now be executed using either of the following methods:

- **Without PHP explicitly:**
  ```sh
  maintenance/run MirahezeMagic:CheckWikiDatabases
  ```
- **Using PHP:**
  ```sh
  php maintenance/run.php MirahezeMagic:CheckWikiDatabases
  ```

This change significantly simplifies calling maintenance scripts, reducing the steps needed.

#### Impact on Miraheze:

For Miraheze, this means scripts can now be executed using mwscript more conveniently. For example:

```sh
mwscript MirahezeMagic:CheckWikiDatabases
```