### PR TITLE
add Miraheze key to APIQuerySiteInfoGeneralInfo

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -66,6 +66,9 @@
 		"AbuseFilterShouldFilterAction": {
 			"handler": "Main"
 		},
+		"APIQuerySiteInfoGeneralInfo": {
+			"handler": "Main"
+		},
 		"BlockIpComplete": {
 			"handler": "Main"
 		},

--- a/includes/HookHandlers/Main.php
+++ b/includes/HookHandlers/Main.php
@@ -2,7 +2,6 @@
 
 namespace Miraheze\MirahezeMagic\HookHandlers;
 
-use MediaWiki\Api\ApiQuerySiteinfo;
 use MediaWiki\Api\Hook\APIQuerySiteInfoGeneralInfoHook;
 use MediaWiki\Cache\Hook\MessageCacheFetchOverridesHook;
 use MediaWiki\CommentStore\CommentStore;
@@ -153,7 +152,7 @@ class Main implements
 		}
 	}
 
-	public function onAPIQuerySiteInfoGeneralInfo( ApiQuerySiteInfo $module, array &$result ): void {
+	public function onAPIQuerySiteInfoGeneralInfo( $module, &$result ) {
 		$result['miraheze'] = true;
 	}
 

--- a/includes/HookHandlers/Main.php
+++ b/includes/HookHandlers/Main.php
@@ -3,6 +3,7 @@
 namespace Miraheze\MirahezeMagic\HookHandlers;
 
 use MediaWiki\Api\ApiQuerySiteinfo;
+use MediaWiki\Api\Hook\APIQuerySiteInfoGeneralInfoHook;
 use MediaWiki\Cache\Hook\MessageCacheFetchOverridesHook;
 use MediaWiki\CommentStore\CommentStore;
 use MediaWiki\Config\Config;
@@ -13,7 +14,6 @@ use MediaWiki\Extension\AbuseFilter\AbuseFilterServices;
 use MediaWiki\Extension\AbuseFilter\Hooks\AbuseFilterShouldFilterActionHook;
 use MediaWiki\Extension\AbuseFilter\Variables\VariableHolder;
 use MediaWiki\Extension\CentralAuth\User\CentralAuthUser;
-use MediaWiki\Hook\APIQuerySiteInfoGeneralInfoHook;
 use MediaWiki\Hook\BlockIpCompleteHook;
 use MediaWiki\Hook\ContributionsToolLinksHook;
 use MediaWiki\Hook\GetLocalURL__InternalHook;

--- a/includes/HookHandlers/Main.php
+++ b/includes/HookHandlers/Main.php
@@ -2,6 +2,7 @@
 
 namespace Miraheze\MirahezeMagic\HookHandlers;
 
+use MediaWiki\Api\ApiQuerySiteinfo;
 use MediaWiki\Cache\Hook\MessageCacheFetchOverridesHook;
 use MediaWiki\CommentStore\CommentStore;
 use MediaWiki\Config\Config;
@@ -12,6 +13,7 @@ use MediaWiki\Extension\AbuseFilter\AbuseFilterServices;
 use MediaWiki\Extension\AbuseFilter\Hooks\AbuseFilterShouldFilterActionHook;
 use MediaWiki\Extension\AbuseFilter\Variables\VariableHolder;
 use MediaWiki\Extension\CentralAuth\User\CentralAuthUser;
+use MediaWiki\Hook\APIQuerySiteInfoGeneralInfoHook;
 use MediaWiki\Hook\BlockIpCompleteHook;
 use MediaWiki\Hook\ContributionsToolLinksHook;
 use MediaWiki\Hook\GetLocalURL__InternalHook;
@@ -51,6 +53,7 @@ use Wikimedia\Rdbms\IConnectionProvider;
 
 class Main implements
 	AbuseFilterShouldFilterActionHook,
+	APIQuerySiteInfoGeneralInfoHook,
 	BlockIpCompleteHook,
 	ContributionsToolLinksHook,
 	CreateWikiDeletionHook,
@@ -148,6 +151,10 @@ class Main implements
 
 			return false;
 		}
+	}
+
+	public function onAPIQuerySiteInfoGeneralInfo( ApiQuerySiteInfo $module, array &$result ): void {
+		$result['miraheze'] = true;
 	}
 
 	public function onCreateWikiDeletion( DBConnRef $cwdb, string $dbname ): void {


### PR DESCRIPTION
Indicate a Miraheze wiki in the query api siteinfo general info. This allows to easily identify even custom domain Miraheze wikis though the MW api.

https://meta.miraheze.org/w/api.php?action=query&meta=siteinfo