### PR TITLE
Add support for CheckUser global table

### DIFF
--- a/includes/HookHandlers/CreateWiki.php
+++ b/includes/HookHandlers/CreateWiki.php
@@ -355,6 +355,7 @@ class CreateWiki implements
 
 	/** @inheritDoc */
 	public function onCreateWikiTables( array &$tables ): void {
+		$tables['cuci_wiki_map'] = 'ciwm_wiki';
 		$tables['localnames'] = 'ln_wiki';
 		$tables['localuser'] = 'lu_wiki';
 	}

--- a/maintenance/CheckWikiDatabases.php
+++ b/maintenance/CheckWikiDatabases.php
@@ -140,6 +140,9 @@ class CheckWikiDatabases extends Maintenance {
 		$suffix = $this->getConfig()->get( 'CreateWikiDatabaseSuffix' );
 
 		$tablesToCheck = [
+			'virtual-checkuser-global' => [
+				'cuci_wiki_map' => 'ciwm_wiki',
+			],
 			'virtual-createwiki' => [
 				'cw_wikis' => 'wiki_dbname',
 				'gnf_files' => 'files_dbname',


### PR DESCRIPTION
This is needed to make GlobalContributions work. If there are unknown databases in this field, then it breaks GlobalContributions.