### PR TITLE
Disable Special:GlobalVanishRequest

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -4,6 +4,7 @@
 	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
 		<exclude name="Generic.Files.LineLength.TooLong" />
 		<exclude name="MediaWiki.Commenting" />
+		<exclude name="MediaWiki.NamingConventions.LowerCamelFunctionsName.FunctionName" />
 	</rule>
 	<rule ref="Generic.Functions.FunctionCallArgumentSpacing.TooMuchSpaceAfterComma">
 		<severity>5</severity>

--- a/extension.json
+++ b/extension.json
@@ -132,6 +132,9 @@
 		"SkinAddFooterLinks": {
 			"handler": "Main"
 		},
+		"SpecialPage_initList": {
+			"handler": "Specials"
+		},
 		"SpecialPageBeforeExecute": {
 			"handler": "Specials"
 		},

--- a/i18n/miraheze/en.json
+++ b/i18n/miraheze/en.json
@@ -112,6 +112,7 @@
 	"miraheze-emailuser-disabled-title": "Emailing users is disabled",
 	"miraheze-emailuser-disabled-message": "Due to local laws and regulations in some jurisdictions, EmailUser has been disabled. If you need to contact another user, please try using their talk page.",
 	"miraheze-faq": "FAQ",
+	"miraheze-globalvanishrequest-disabled-message": "If you wish to disable your account, use one of [[meta:Disabling an account|these methods]] documented on Miraheze Meta.",
 	"miraheze-helpcenter": "Miraheze Help Center",
 	"miraheze-label-managewiki-article-path": "Article path",
 	"miraheze-label-managewiki-article-path-root": "Don't use /wiki/ for articles (use the root path)",

--- a/i18n/miraheze/en.json
+++ b/i18n/miraheze/en.json
@@ -113,6 +113,7 @@
 	"miraheze-emailuser-disabled-title": "Emailing users is disabled",
 	"miraheze-emailuser-disabled-message": "Due to local laws and regulations in some jurisdictions, EmailUser has been disabled. If you need to contact another user, please try using their talk page.",
 	"miraheze-faq": "FAQ",
+	"miraheze-globalvanishrequest-disabled-message": "If you wish to disable your account, use one of [[meta:Disabling an account|these methods]] documented on Miraheze Meta.",
 	"miraheze-helpcenter": "Miraheze Help Center",
 	"miraheze-label-managewiki-article-path": "Article path",
 	"miraheze-label-managewiki-article-path-root": "Don't use /wiki/ for articles (use the root path)",

--- a/i18n/miraheze/qqq.json
+++ b/i18n/miraheze/qqq.json
@@ -88,6 +88,7 @@
 	"miraheze-emailuser-disabled-title": "Title for Special:EmailUser when the user cannot email users because of local laws and regulations",
 	"miraheze-emailuser-disabled-message": "Body for Special:EmailUser when the user cannot email users because of local laws and regulations",
 	"miraheze-faq": "Label for the Frequently Asked Questions.\n{{Identical|FAQ}}",
+	"miraheze-globalvanishrequest-disabled-message": "Message displayed when accessing Special:GlobalVanishRequest, which is disabled.",
 	"miraheze-helpcenter": "Link for the help center page.",
 	"miraheze-requestfeatures": "Request features on a wiki",
 	"miraheze-requestwiki": "Request a wiki",

--- a/includes/HookHandlers/Specials.php
+++ b/includes/HookHandlers/Specials.php
@@ -3,6 +3,7 @@
 namespace Miraheze\MirahezeMagic\HookHandlers;
 
 use MediaWiki\Exception\ErrorPageError;
+use MediaWiki\SpecialPage\DisabledSpecialPage;
 use MediaWiki\SpecialPage\Hook\SpecialPageBeforeExecuteHook;
 use MediaWiki\Specials\SpecialEmailUser;
 
@@ -26,5 +27,14 @@ class Specials implements SpecialPageBeforeExecuteHook {
 		}
 
 		throw new ErrorPageError( 'miraheze-emailuser-disabled-title', 'miraheze-emailuser-disabled-message' );
+	}
+
+	/** @inheritDoc */
+	public function onSpecialPage_initList( array &$specialPages ) {
+		if ( !isset( $specialPages['GlobalVanishRequest'] ) ) {
+			return true;
+		}
+
+		$specialPages['GlobalVanishRequest'] = DisabledSpecialPage::getCallback( 'GlobalVanishRequest', 'miraheze-globalvanishrequest-disabled-message' );
 	}
 }

--- a/includes/HookHandlers/Specials.php
+++ b/includes/HookHandlers/Specials.php
@@ -3,10 +3,15 @@
 namespace Miraheze\MirahezeMagic\HookHandlers;
 
 use MediaWiki\Exception\ErrorPageError;
+use MediaWiki\SpecialPage\DisabledSpecialPage;
+use MediaWiki\SpecialPage\Hook\SpecialPage_initListHook;
 use MediaWiki\SpecialPage\Hook\SpecialPageBeforeExecuteHook;
 use MediaWiki\Specials\SpecialEmailUser;
 
-class Specials implements SpecialPageBeforeExecuteHook {
+// MediaWiki core uses SpecialPage_initList as the hook name.
+// phpcs:disable MediaWiki.NamingConventions.LowerCamelFunctionsName.FunctionName
+
+class Specials implements SpecialPageBeforeExecuteHook, SpecialPage_initListHook {
 
 	public function __construct() {
 	}
@@ -26,5 +31,14 @@ class Specials implements SpecialPageBeforeExecuteHook {
 		}
 
 		throw new ErrorPageError( 'miraheze-emailuser-disabled-title', 'miraheze-emailuser-disabled-message' );
+	}
+
+	/** @inheritDoc */
+	public function onSpecialPage_initList( &$list ) {
+		if ( !isset( $list['GlobalVanishRequest'] ) ) {
+			return true;
+		}
+
+		$list['GlobalVanishRequest'] = DisabledSpecialPage::getCallback( 'GlobalVanishRequest', 'miraheze-globalvanishrequest-disabled-message' );
 	}
 }


### PR DESCRIPTION
Miraheze doesn't use it, and it unnecessarily appears in the list of special pages. I can't test this pull request, though, someone else will have to do that.