### PR TITLE
Update site notice styling

### DIFF
--- a/includes/HookHandlers/Main.php
+++ b/includes/HookHandlers/Main.php
@@ -297,7 +297,7 @@ class Main implements
 		$imageHtml = Html::element( 'img', [
 			'src' => $imageUrl,
 			'align' => 'left',
-			'style' => 'width: 80px; height: 90px;',
+			'style' => 'max-width: 80px; max-height: 90px;',
 		] );
 
 		$spanHtml = Html::rawElement( 'span',
@@ -307,7 +307,7 @@ class Main implements
 
 		$divHtml = Html::rawElement( 'div', [
 			'class' => 'wikitable',
-			'style' => 'text-align: center; width: 90%; margin-left: auto; margin-right: auto; padding: 15px; border: 4px solid black; background-color: var(--background-color-neutral, #EEE);',
+			'style' => 'text-align: center; width: 90%; margin-left: auto; margin-right: auto; padding: 15px; border: 4px solid black; background-color: var(--background-color-neutral, #EEE); overflow: auto;',
 		], $spanHtml );
 
 		$siteNotice .= $divHtml;

--- a/includes/HookHandlers/Main.php
+++ b/includes/HookHandlers/Main.php
@@ -307,8 +307,8 @@ class Main implements
 
 		$divHtml = Html::rawElement( 'div', [
 			'class' => 'wikitable',
-			'style' => 'text-align: center; width: 90%; margin-left: auto; margin-right: auto; padding: 15px; border: 4px solid black; background-color: var(--background-color-neutral, #EEE); overflow: auto;',
-		], $spanHtml );
+			'style' => 'text-align: center; width: 90%; margin-left: auto; margin-right: auto; padding: 15px; border: 4px solid black; background-color: var(--background-color-neutral, #EEE);',
+		], $spanHtml . '<div style="clear: both;"></div>' );
 
 		$siteNotice .= $divHtml;
 	}

--- a/includes/HookHandlers/Main.php
+++ b/includes/HookHandlers/Main.php
@@ -305,7 +305,7 @@ class Main implements
 			$imageHtml . $message
 		);
 
-		$clearHtml = Html::Element( 'div', [ 'style' => 'clear: both;' ] );
+		$clearHtml = Html::element( 'div', [ 'style' => 'clear: both;' ] );
 
 		$divHtml = Html::rawElement( 'div', [
 			'class' => 'wikitable',

--- a/includes/HookHandlers/Main.php
+++ b/includes/HookHandlers/Main.php
@@ -305,10 +305,12 @@ class Main implements
 			$imageHtml . $message
 		);
 
+		$clearHtml = Html::Element( 'div', [ 'style' => 'clear: both;' ] );
+
 		$divHtml = Html::rawElement( 'div', [
 			'class' => 'wikitable',
 			'style' => 'text-align: center; width: 90%; margin-left: auto; margin-right: auto; padding: 15px; border: 4px solid black; background-color: var(--background-color-neutral, #EEE);',
-		], $spanHtml . '<div style="clear: both;"></div>' );
+		], $spanHtml . $clearHtml );
 
 		$siteNotice .= $divHtml;
 	}


### PR DESCRIPTION
See https://discord.com/channels/407504499280707585/1019689826762637382/threads/1537299057360371762 for full explanation of issues, basically the inactivity notice's clock image (seen on e.g. https://voidstranger.miraheze.org/wiki/Void_Stranger_Wiki) was both badly-proportioned and extended past the edges of the notice.

The current changes in this PR are a simple hotfix, there's probably a better way to do it